### PR TITLE
address cases when there is no multilib lines in original config

### DIFF
--- a/tests/configuration/.tomty/ansible-enable-arch-multilib-repo-01.raku
+++ b/tests/configuration/.tomty/ansible-enable-arch-multilib-repo-01.raku
@@ -2,11 +2,10 @@
 
 copy "examples/pacman1.conf", "/tmp/pacman.conf";
 
-bash q:to /CODE/, %( :description<run ansible> );
-  ansible-playbook -i localhost, \
-  ../../airootfs//root/bind-mount/root/enable-arch-multilib-repo.yaml \
-  -e "enable_multilib=y config_path=/tmp/pacman.conf"
-CODE
+task-run "tasks/run-ansible", %(
+  :playbook<../../airootfs//root/bind-mount/root/enable-arch-multilib-repo.yaml>,
+  vars => "enable_multilib=y config_path=/tmp/pacman.conf",
+);
 
 task-run "tasks/arch-multilib-repo-is-enabled", %(
   :path</tmp/pacman.conf>,

--- a/tests/configuration/.tomty/ansible-enable-arch-multilib-repo-02.raku
+++ b/tests/configuration/.tomty/ansible-enable-arch-multilib-repo-02.raku
@@ -2,11 +2,10 @@
 
 copy "examples/pacman1.conf", "/tmp/pacman.conf";
 
-bash q:to /CODE/, %( :description<run ansible> );
-  ansible-playbook -i localhost, \
-  ../../airootfs//root/bind-mount/root/enable-arch-multilib-repo.yaml \
-  -e "enable_multilib=n config_path=/tmp/pacman.conf"
-CODE
+task-run "tasks/run-ansible", %(
+  :playbook<../../airootfs//root/bind-mount/root/enable-arch-multilib-repo.yaml>,
+  vars => "enable_multilib=n config_path=/tmp/pacman.conf",
+);
 
 task-run "tasks/arch-multilib-repo-is-commented", %(
   :path</tmp/pacman.conf>,

--- a/tests/configuration/.tomty/ansible-enable-arch-multilib-repo-03.raku
+++ b/tests/configuration/.tomty/ansible-enable-arch-multilib-repo-03.raku
@@ -2,12 +2,10 @@
 
 copy "examples/pacman2.conf", "/tmp/pacman.conf";
 
-bash q:to /CODE/, %( :description<run ansible> );
-  ansible-playbook -i localhost, \
-  ../../airootfs//root/bind-mount/root/enable-arch-multilib-repo.yaml \
-  -e "enable_multilib=y config_path=/tmp/pacman.conf"
-CODE
-
-task-run "tasks/arch-multilib-repo-is-enabled", %(
-  :path</tmp/pacman.conf>,
+task-run "tasks/run-ansible", %(
+  :should_fail,
+  :playbook<../../airootfs//root/bind-mount/root/enable-arch-multilib-repo.yaml>,
+  vars => "enable_multilib=y config_path=/tmp/pacman.conf",
+  :error_message<Missing multilib configuration in pacman.conf>,
 );
+

--- a/tests/configuration/.tomty/ansible-enable-arch-multilib-repo-04.raku
+++ b/tests/configuration/.tomty/ansible-enable-arch-multilib-repo-04.raku
@@ -2,12 +2,10 @@
 
 copy "examples/pacman2.conf", "/tmp/pacman.conf";
 
-bash q:to /CODE/, %( :description<run ansible> );
-  ansible-playbook -i localhost, \
-  ../../airootfs//root/bind-mount/root/enable-arch-multilib-repo.yaml \
-  -e "enable_multilib=n config_path=/tmp/pacman.conf"
-CODE
-
-task-run "tasks/arch-multilib-repo-is-commented", %(
-  :path</tmp/pacman.conf>,
+task-run "tasks/run-ansible", %(
+  :should_fail,
+  :playbook<../../airootfs//root/bind-mount/root/enable-arch-multilib-repo.yaml>,
+  vars => "enable_multilib=n config_path=/tmp/pacman.conf",
+  :error_message<Missing multilib configuration in pacman.conf>,
 );
+

--- a/tests/configuration/.tomty/ansible-enable-arch-multilib-repo-05.raku
+++ b/tests/configuration/.tomty/ansible-enable-arch-multilib-repo-05.raku
@@ -2,11 +2,10 @@
 
 copy "examples/pacman3.conf", "/tmp/pacman.conf";
 
-bash q:to /CODE/, %( :description<run ansible> );
-  ansible-playbook -i localhost, \
-  ../../airootfs//root/bind-mount/root/enable-arch-multilib-repo.yaml \
-  -e "enable_multilib=y config_path=/tmp/pacman.conf"
-CODE
+task-run "tasks/run-ansible", %(
+  :playbook<../../airootfs//root/bind-mount/root/enable-arch-multilib-repo.yaml>,
+  vars => "enable_multilib=y config_path=/tmp/pacman.conf",
+);
 
 task-run "tasks/arch-multilib-repo-is-enabled", %(
   :path</tmp/pacman.conf>,

--- a/tests/configuration/.tomty/ansible-enable-arch-multilib-repo-06.raku
+++ b/tests/configuration/.tomty/ansible-enable-arch-multilib-repo-06.raku
@@ -2,12 +2,11 @@
 
 copy "examples/pacman3.conf", "/tmp/pacman.conf";
 
-bash q:to /CODE/, %( :description<run ansible> );
-  ansible-playbook -i localhost, \
-  ../../airootfs//root/bind-mount/root/enable-arch-multilib-repo.yaml \
-  -e "enable_multilib=n config_path=/tmp/pacman.conf"
-CODE
+task-run "tasks/run-ansible", %(
+  :playbook<../../airootfs//root/bind-mount/root/enable-arch-multilib-repo.yaml>,
+  vars => "enable_multilib=n config_path=/tmp/pacman.conf",
+);
 
-task-run "tasks/arch-multilib-repo-is-commented", %(
+task-run "tasks/arch-multilib-repo-is-enabled", %(
   :path</tmp/pacman.conf>,
 );

--- a/tests/configuration/.tomty/ansible-enable-arch-multilib-repo-06.raku
+++ b/tests/configuration/.tomty/ansible-enable-arch-multilib-repo-06.raku
@@ -7,6 +7,6 @@ task-run "tasks/run-ansible", %(
   vars => "enable_multilib=n config_path=/tmp/pacman.conf",
 );
 
-task-run "tasks/arch-multilib-repo-is-enabled", %(
+task-run "tasks/arch-multilib-repo-is-commented", %(
   :path</tmp/pacman.conf>,
 );

--- a/tests/configuration/tasks/run-ansible/config.yaml
+++ b/tests/configuration/tasks/run-ansible/config.yaml
@@ -1,0 +1,4 @@
+should_fail: false
+playbook: foo.yaml
+vars: ""
+error_message: ""

--- a/tests/configuration/tasks/run-ansible/task.bash
+++ b/tests/configuration/tasks/run-ansible/task.bash
@@ -1,0 +1,14 @@
+set -e
+
+playbook=$(config playbook)
+echo "playbook: $playbook"
+
+vars=$(config vars)
+echo "playbook: $vars"
+
+set +e
+ansible-playbook -i localhost, $playbook -e "$vars"
+exit_code=$?
+set -e
+
+echo "exit_code: $exit_code"

--- a/tests/configuration/tasks/run-ansible/task.check
+++ b/tests/configuration/tasks/run-ansible/task.check
@@ -1,0 +1,27 @@
+within: ^^ "exit_code: " (\S+) $$
+    ~regexp: (\d+)
+end:
+
+generator: <<RAKU
+!raku
+if matched() {
+    my $code = capture()[0].Int;
+    say "assert: 1 valid exit code $code found";
+    if config()<should_fail> {
+        if $code != 0 {
+            say "assert: 1 exit code != 0";
+            say "regexp: \"{config()<error_message>}\"";
+        } else {
+            say "assert: 0 exit code != 0";
+        }
+    } else {
+        if $code == 0 {
+            say "assert: 1 exit code == 0";
+        } else {
+            say "assert: 0 exit code == 0";
+        }
+    }
+} else {
+    say "assert: 0 valid exit code found";
+}
+RAKU


### PR DESCRIPTION
In case3 and case4 we have now:

```
22:07:57 :: ...ignoring
22:07:57 :: 
22:07:57 :: TASK [Fail if multilib configuration is missing] *******************************
22:07:57 :: fatal: [localhost]: FAILED! => {"changed": false, "msg": "Missing multilib configuration in pacman.conf"}
22:07:57 :: 
22:07:57 :: PLAY RECAP *********************************************************************
22:07:57 :: localhost                  : ok=2    changed=0    unreachable=0    failed=1    skipped=0    rescued=0    ignored=1   
22:07:57 :: 
22:07:57 :: exit_code: 2
[task stderr]
22:07:57 :: [WARNING]: Platform darwin on host localhost is using the discovered Python
22:07:57 :: interpreter at /Users/alex/homebrew/bin/python3.10, but future installation of
22:07:57 :: another Python interpreter could change the meaning of that path. See
22:07:57 :: https://docs.ansible.com/ansible-
22:07:57 :: core/2.13/reference_appendices/interpreter_discovery.html for more information.
[task check]
stdout match (w) <(\d+)> True
<valid exit code 2 found> True
<exit code != 0> True
stdout match <"Missing multilib configuration in pacman.conf"> True
``` 